### PR TITLE
[COM-888] add correct type mapping in finder for date

### DIFF
--- a/src/Knp/FriendlyContexts/Doctrine/EntityFinder.php
+++ b/src/Knp/FriendlyContexts/Doctrine/EntityFinder.php
@@ -68,6 +68,10 @@ class EntityFinder
             if (!in_array($metadata['type'], [DBALType::JSON_ARRAY])) {
                 $criterias[$property] = $this->clean($value);
             }
+
+            if (in_array($metadata['type'], [DBALType::DATETIME, DBALType::DATE, DBALType::DATETIMETZ])) {
+                $criterias[$property] = empty($criterias[$property]) ? null : new \DateTime($criterias[$property]);
+            }
         }
 
         return $criterias;


### PR DESCRIPTION
Actually if you try this : 
```gherkin
        Then should be 1 analyze like:
            | status       | executedAt                       |
            | SUCCESS |  2017-01-08T03:00:00Z |
```

It will fail because the date will be mapped as string in the doctrine criterias.

Here, I do the correct mapping